### PR TITLE
Mobile search changes - CSS Adjustments

### DIFF
--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -2,7 +2,7 @@
 <label class="panel_mobile_button" for="hamburger"><span></span> Menu</label>
 <div class="panel panel_tree" id="panel" data-turbolinks-permanent>
   <div class="header">
-    <input type="text" placeholder="Search for a class, method, ..." autosave="searchdoc" results="10" id="search" autocomplete="off" />
+    <input type="search" placeholder="Search for a class, method, ..." autosave="searchdoc" results="10" id="search" autocomplete="off" />
     <label class="panel_mobile_button_close" for="hamburger"><span></span> Close</label>
   </div>
   <div class="tree">

--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -2,7 +2,7 @@
 <label class="panel_mobile_button" for="hamburger"><span></span> Menu</label>
 <div class="panel panel_tree" id="panel" data-turbolinks-permanent>
   <div class="header">
-    <input type="search" placeholder="Search for a class, method, ..." autosave="searchdoc" results="10" id="search" autocomplete="off" />
+    <input type="search" placeholder="Search for a class, method, ..." autosave="searchdoc" results="10" id="search" autocomplete="off" tabindex="-1" />
     <label class="panel_mobile_button_close" for="hamburger"><span></span> Close</label>
   </div>
   <div class="tree">

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -16,6 +16,7 @@
             text-align: right;
             line-height: 40px;
             cursor: pointer;
+            z-index: 2;
         }
         .panel_checkbox:checked ~ .panel_mobile_button {
         }
@@ -83,7 +84,7 @@
         width: 300px;
         height: 100%;
         background: #FFF;
-        z-index: 2;
+        z-index: 10;
         font-family: "Helvetica Neue", "Arial", sans-serif;
         overflow-x: hidden;
         border-right: 1px #ccc solid;
@@ -93,15 +94,15 @@
     @media (max-width: 39.99em) {
         .panel
         {
-            transform: translate(-100%, 0);
-            transition: transform 0s ease-in-out;
+            transition: left 0.3s ease-in-out;
+            left: -100%;
             width: 100%;
             bottom: 0;
         }
 
         .panel_checkbox:checked ~ .panel {
-            transform: translate(0, 0);
-            transition: transform 0.3s ease-in-out;
+            left: 0%;
+            transition: left 0.3s ease-in-out;
         }
     }
 

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -94,15 +94,17 @@
     @media (max-width: 39.99em) {
         .panel
         {
-            transition: left 0.3s ease-in-out;
+            transition: left 0s ease-in-out;
             left: -100%;
             width: 100%;
             bottom: 0;
+            visibility: hidden; 
         }
 
         .panel_checkbox:checked ~ .panel {
             left: 0%;
             transition: left 0.3s ease-in-out;
+            visibility: visible;
         }
     }
 

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -93,15 +93,15 @@
     @media (max-width: 39.99em) {
         .panel
         {
-            transform:translate(-100%, 0);
-            transition:transform 0s ease-in-out;
+            transform: translate(-100%, 0);
+            transition: transform 0s ease-in-out;
             opacity: 0;
             width: 100%
         }
 
         .panel_checkbox:checked ~ .panel {
-            transform:translate(0, 0);
-            transition:transform 0.3s ease-in-out;
+            transform: translate(0, 0);
+            transition: transform 0.3s ease-in-out;
             opacity: 1;
         }
     }

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -156,7 +156,7 @@
         {
             position: relative;
             bottom: 0;
-            top: 40px;
+            top: 0;
             left: 0;
             width: 100%;
             overflow-y: auto;

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -148,6 +148,14 @@
             outline: none;
         }
 
+        @media (max-width: 39.99em) {
+            .panel .header input
+            {
+                width: 70%;
+                width: calc(100% - 100px);
+            }
+        }
+
     /* Header with search box (end) */
 
 

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -69,16 +69,10 @@
     }
 
     .panel_mobile_button_close span:before {
-        -webkit-transform: rotate(45deg);
-        -moz-transform: rotate(45deg);
-        -ms-transform: rotate(45deg);
         transform: rotate(45deg);
     }
 
     .panel_mobile_button_close span:after {
-        -webkit-transform: rotate(-45deg);
-        -moz-transform: rotate(-45deg);
-        -ms-transform: rotate(-45deg);
         transform: rotate(-45deg);
     }
 
@@ -99,26 +93,14 @@
     @media (max-width: 39.99em) {
         .panel
         {
-            -webkit-transform:translate(-100%, 0);
-            -moz-transform:translate(-100%, 0);
-            -ms-transform:translate(-100%, 0);
             transform:translate(-100%, 0);
-             -webkit-transition:transform 0s ease-in-out;
-            -moz-transition:transform 0s ease-in-out;
-            -ms-transition:transform 0s ease-in-out;
             transition:transform 0s ease-in-out;
             opacity: 0;
             width: 100%
         }
 
         .panel_checkbox:checked ~ .panel {
-            -webkit-transform:translate(0, 0);
-            -moz-transform:translate(0, 0);
-            -ms-transform:translate(0, 0);
             transform:translate(0, 0);
-            -webkit-transition:transform 0.3s ease-in-out;
-            -moz-transition:transform 0.3s ease-in-out;
-            -ms-transition:transform 0.3s ease-in-out;
             transition:transform 0.3s ease-in-out;
             opacity: 1;
         }

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -153,6 +153,7 @@
             {
                 width: 70%;
                 width: calc(100% - 100px);
+                font-size: 16px;
             }
         }
 

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -106,6 +106,10 @@
             transition: left 0.3s ease-in-out;
             visibility: visible;
         }
+
+        .panel_checkbox:checked ~ #bodyContent {
+            visibility: hidden;
+        }
     }
 
     .panel_tree .results,

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -109,6 +109,7 @@
 
         .panel_checkbox:checked ~ #bodyContent {
             visibility: hidden;
+            display: none;
         }
     }
 

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -95,14 +95,13 @@
         {
             transform: translate(-100%, 0);
             transition: transform 0s ease-in-out;
-            opacity: 0;
-            width: 100%
+            width: 100%;
+            bottom: 0;
         }
 
         .panel_checkbox:checked ~ .panel {
             transform: translate(0, 0);
             transition: transform 0.3s ease-in-out;
-            opacity: 1;
         }
     }
 


### PR DESCRIPTION
These are the tweaks mentioned in https://github.com/zzak/sdoc/pull/154 along with a few fixes I noticed :)

# Key Changes

- `.panel_mobile_button` (Black header bar) would sometimes fall behind the normal text, so I adjust the z-index's to put is above the main text but under `.panel`
- Removed the vendor prefixes
- Transformed the `left` CSS property, I kept seeing rendering weirdness on Firefox when I opened/close the panel
- Made the search input smaller so it wouldn't cover the "close" button
- Made the panel max height to the bottom of the page, so if you open it while partially scrolled you can still see it.
- The results had a weird whitespace above it (I think due to the panel now being fixed), so pushed it up a tad.

# How I tested this

I pull down the branch locally and ran:

```bash
$ rake install && sdoc -o doc/rails -T rails -f sdoc
$ rackup config.ru --host=0.0.0.0
```

I was then able to open it in Firefox on responsive mode, and also on Safari on my iPhone. I tweaked as I noticed thing seemed off.

## iOS VoiceOver

To check accessibility, I enabled VoiceOver on my phone & used the feature a bunch. I did spot a few small things which I fixed, I'll try to make a video so you can see the difference.

# Previewing the changes:

I setup a preview on Netlify: https://condescending-hoover-56ea7f.netlify.app/ - Do you want a PR/issue for doing this automatically on PRs? I know I found it very hand :)